### PR TITLE
Feature/add published at field

### DIFF
--- a/client/src/components/home/BlogPostCard.tsx
+++ b/client/src/components/home/BlogPostCard.tsx
@@ -34,7 +34,8 @@ const BlogPostCard = ({
     description,
     coverImgURL,
     tags,
-    createdAt: publishedAt,
+    createdAt,
+    publishedAt,
     activity,
   } = content;
 
@@ -61,7 +62,11 @@ const BlogPostCard = ({
                   {fullname}
                 </p>
                 <p className="text-muted-foreground font-normal">
-                  {publishedAt && showTimeAgo
+                  {isDraft
+                    ? createdAt && showTimeAgo
+                      ? getTimeAgo(createdAt)
+                      : formatDate(createdAt)
+                    : publishedAt && showTimeAgo
                     ? getTimeAgo(publishedAt)
                     : formatDate(publishedAt)}
                 </p>

--- a/client/src/pages/PublishedBlogPage.tsx
+++ b/client/src/pages/PublishedBlogPage.tsx
@@ -91,7 +91,7 @@ const PublishedBlogPage = () => {
     likes,
     activity,
     content,
-    createdAt: publishedAt,
+    publishedAt,
     isDraft,
     description,
   } = blog;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -89,6 +89,7 @@ export interface IBlog {
   authorDetails: IAuthor;
   content: OutputData;
   createdAt?: string; //timestamp
+  publishedAt?: string; //timestamp
   activity?: {
     totalLikes: number;
     totalReads: number;

--- a/server/src/controllers/blog.controller.ts
+++ b/server/src/controllers/blog.controller.ts
@@ -263,6 +263,7 @@ const getAllPublishedBlogs = async (req: Request, res: Response) => {
         tags: 1,
         activity: 1,
         createdAt: 1,
+        publishedAt: 1,
         "authorDetails.personalInfo.fullname": 1,
         "authorDetails.personalInfo.username": 1,
         "authorDetails.personalInfo.profileImage": 1,
@@ -303,7 +304,7 @@ const getPublishedBlogById = async (req: Request, res: Response) => {
         "_id personalInfo.fullname personalInfo.username personalInfo.profileImage",
     })
     .select(
-      "blogId title description content coverImgURL author tags activity createdAt likes isDraft _id"
+      "blogId title description content coverImgURL author tags activity createdAt likes isDraft publishedAt _id"
     )
     .lean();
 
@@ -633,7 +634,7 @@ const getDraftBlogById = async (req: Request, res: Response) => {
   // fetch the draft blog
   const draftBlog = await Blog.findOne({ blogId, isDraft: true })
     .select(
-      "_id blogId title description content coverImgURL author tags createdAt"
+      "_id blogId title description content coverImgURL author tags createdAt publishedAt"
     )
     .lean();
 

--- a/server/src/controllers/blog.controller.ts
+++ b/server/src/controllers/blog.controller.ts
@@ -184,16 +184,16 @@ const getAllPublishedBlogs = async (req: Request, res: Response) => {
 
   // Query for cursor based pagination
   // Fetch documents older than the cursor's timestamp, or with the same timestamp but a smaller ID.
-  //    1. Fetch documents where `createdAt` timestamp is less than the cursor's timestamp.
+  //    1. Fetch documents where `publishedAt` timestamp is less than the cursor's timestamp.
   //    2. If timestamps are equal, use `_id` to break ties and fetch documents with a smaller `_id`.
   let cursorQuery = {};
   if (nextCursor) {
-    const [createdAt, id] = (nextCursor as string).split("_");
+    const [publishedAtTimestamp, id] = (nextCursor as string).split("_");
     cursorQuery = {
       $or: [
-        { createdAt: { $lt: new Date(createdAt) } },
+        { publishedAt: { $lt: new Date(publishedAtTimestamp) } },
         {
-          createdAt: new Date(createdAt),
+          publishedAt: new Date(publishedAtTimestamp),
           _id: { $lt: new Types.ObjectId(id) },
         },
       ],
@@ -225,9 +225,9 @@ const getAllPublishedBlogs = async (req: Request, res: Response) => {
       ? {
           "activity.totalReads": -1,
           "activity.totalLikes": -1,
-          createdAt: -1,
+          publishedAt: -1,
         }
-      : { createdAt: -1, _id: -1 };
+      : { publishedAt: -1, _id: -1 };
 
   // Fetch blogs using cursor based pagination
   const blogs = await Blog.aggregate([
@@ -273,14 +273,14 @@ const getAllPublishedBlogs = async (req: Request, res: Response) => {
 
   // Determine the `nextCursor` for pagination
   // - Fetching `limit + 1` documents ensures there is more data beyond the current page.
-  // - If more results exist, `nextCursor` is generated using the `createdAt` timestamp and `_id` of the last document.
+  // - If more results exist, `nextCursor` is generated using the `publishedAt` timestamp and `_id` of the last document.
   // - `nextCursor` acts as a boundary for fetching the next page while maintaining stable ordering,
   //    ensuring that records are neither skipped nor duplicated between pages when data is updated.
   let cursor = null;
   if (blogs.length > finalLimit) {
     blogs.pop(); // Remove extra item
     const lastBlog = blogs[blogs.length - 1]; // get last item from current page
-    cursor = `${lastBlog.createdAt.toISOString()}_${lastBlog._id}`;
+    cursor = `${lastBlog.publishedAt.toISOString()}_${lastBlog._id}`;
   }
 
   const data: CursorPaginatedAPIResponse = {

--- a/server/src/db/migration.ts
+++ b/server/src/db/migration.ts
@@ -10,13 +10,7 @@ connectDB();
 const db = mongoose.connection;
 db.once("open", async () => {
   try {
-    // await addActivityFieldToBlog();
-    // await addSocialLinksFieldToUser();
-    // //  await updateContentFieldType();
-    // await addLikesFieldToBlog();
-    // // await deleteCommentsFieldOnBlog();
-
-    // await updateCommentsSchema();
+    await addPublishedAtFieldToBlog();
     console.log("Migration completed successfully!");
   } catch (error) {
     console.error("Migration failed:", error);
@@ -24,6 +18,25 @@ db.once("open", async () => {
     db.close();
   }
 });
+
+const addPublishedAtFieldToBlog = async () => {
+  // Locate blogs missing the 'publishedAt' field.
+  // For published blogs, set 'publishedAt' to 'createdAt'.
+  // For draft blogs, explicitly set 'publishedAt' to null.
+  await Blog.updateMany({ publishedAt: { $exists: false } }, [
+    {
+      $set: {
+        publishedAt: {
+          $cond: {
+            if: "$isDraft",
+            then: null,
+            else: "$createdAt",
+          },
+        },
+      },
+    },
+  ]);
+};
 
 const addActivityFieldToBlog = async () => {
   // Find blogs without the 'activity' field and update them

--- a/server/src/models/blog.model.ts
+++ b/server/src/models/blog.model.ts
@@ -12,6 +12,7 @@ interface IBlog extends Document {
   tags: string[];
   author: string | IUser["_id"];
   isDraft: boolean;
+  publishedAt: Date | null;
   activity: {
     totalLikes: number;
     totalReads: number;
@@ -19,6 +20,8 @@ interface IBlog extends Document {
     totalParentComments: number;
   };
   likes: Map<string, boolean>;
+  createdAt?: Date;
+  updatedAt?: Date;
 }
 
 const blogSchema = new Schema(
@@ -57,6 +60,7 @@ const blogSchema = new Schema(
       required: true,
       index: true,
     },
+    publishedAt: { type: Date, default: null, index: true },
     activity: {
       totalLikes: { type: Number, default: 0 },
       totalReads: { type: Number, default: 0 },

--- a/server/src/models/blog.model.ts
+++ b/server/src/models/blog.model.ts
@@ -76,9 +76,9 @@ const blogSchema = new Schema(
   { timestamps: true }
 );
 
-// Create a compound index on `createdAt` and `_id` in descending order to optimize cursor-based pagination
-// by efficiently sorting documents based on creation date and document ID.
-blogSchema.index({ createdAt: -1, _id: -1 });
+// Create a compound index on `publishedAt` and `_id` in descending order to optimize cursor-based pagination
+// by efficiently ordering documents using the blog's published date and document ID.
+blogSchema.index({ publishedAt: -1, _id: -1 });
 
 // Virtual field to populate the 'authorDetails' for a blog
 blogSchema.virtual("authorDetails", {

--- a/server/src/utils/index.ts
+++ b/server/src/utils/index.ts
@@ -112,16 +112,16 @@ export const getFormattedExpiryDate = (date: Date): string => {
 };
 
 export const isValidCursor = (cursor: string): boolean => {
-  // Cursor valid format -> `<createdAt>_<id>`
-  const [createdAt, id] = (cursor as string).split("_");
+  // Cursor valid format -> `<timestamp>_<id>`
+  const [timestamp, id] = (cursor as string).split("_");
 
-  if (!createdAt || !id) return false;
+  if (!timestamp || !id) return false;
 
-  // Ensure `createdAt` is a valid ISO 8601 string by checking its format and parsing result
-  const date = new Date(createdAt);
+  // Ensure `timestamp` is a valid ISO 8601 string by checking its format and parsing result
+  const date = new Date(timestamp);
   if (
     isNaN(date.getTime()) || // Ensures it's a valid date
-    createdAt !== date.toISOString() // Ensures exact format match
+    timestamp !== date.toISOString() // Ensures exact format match
   ) {
     return false;
   }


### PR DESCRIPTION
A new `publishedAt` field has been integrated to track blog publication dates, along with enhancements to the publishing workflow. The changes ensure that the publication date is properly reflected across the API and UI,

#### **Changes**
1. Added publishedAt Field:
Introduces a new field to track when a blog post is published.

2. Updated Publishing Workflow:
The publishing process now sets the publishedAt field appropriately.

3. API and UI Enhancements:
    - Exposes publishedAt in the API response.
    - Displays the publication date on the published page and in blog post cards across the feed, search results, and the user's published blog list on their profile.
    - Improved Pagination: Uses `publishedAt` for `cursor-based pagination` on the feed. 
       This fixes the issue where older drafts, when published recently, caused misordering of blog posts.

4. Data Migration Script:
    A migration script has been added to update existing blog records with the new publishedAt field.